### PR TITLE
Allow lib:// to be optional in STORE block

### DIFF
--- a/grammar.pegjs
+++ b/grammar.pegjs
@@ -1591,7 +1591,7 @@ resources
 	}
 
 resource			= name:(
-						lib:'lib://' res:[^ \t\r\n()]+		{ return { value: lib + res.join(''), 					txt: () => computeText(arguments) }; }
+						lib:'lib://'* res:[^ \t\r\n()]+		{ return { value: lib + res.join(''), 					txt: () => computeText(arguments) }; }
 						/ name:('@'? alphanum)				{ return { value: (name[0] ? name[0] : '') + name[1], 	txt: () => computeText(arguments) }; }
 						/ name:braceQuoteString				
 						/ name:doubleQuoteString


### PR DESCRIPTION
Allowing lib:// to be optional allows STORE to be correctly processed when no lib:// -- such as QlikView or Sense Standard mode